### PR TITLE
Update to Ubuntu 24.04

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,9 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      
+      - name: Checkout
+        uses: actions/checkout@v3
         
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,11 +22,9 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         
-      - name: Checkout
-        uses: actions/checkout@v3
-        
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         

--- a/dockerst/Dockerfile
+++ b/dockerst/Dockerfile
@@ -22,7 +22,6 @@ RUN rm -f /etc/ImageMagick-6/policy.xml
 #   See: https://packaging.python.org/en/latest/specifications/externally-managed-environments/
 RUN apt-get update -y \
   && apt-get install -y \
-    python3-arrow \
     python3-click \
     python3-matplotlib \
     python3-pandas \
@@ -39,6 +38,7 @@ RUN apt-get update -y \
 #   See: https://stackoverflow.com/a/76469774/68736
 ENV PIP_BREAK_SYSTEM_PACKAGES 1
 RUN python3 -m pip install \
+    pyarrow \
     torch
 
 # R packages needed

--- a/dockerst/Dockerfile
+++ b/dockerst/Dockerfile
@@ -60,15 +60,17 @@ RUN install.r \
     units uuid \
     yardstick
 
-RUN installGithub.r \
-    cornelllabofornithology/auk \
-    ebird/ebirdst \
-    walkerke/mapboxapi \
-    bgreenwell/fastshap \
-    crazycapivara/h3-r \
-    imbs-hl/ranger \
-    # temporary bug fix, change back to CRAN once new version is on CRAN
-    datastorm-open/suncalc
+# mapboxapi dependencies protolite and magick need to be compiled to avoid shared library errors
+RUN r -e 'install.packages(c("protolite", "magick"), repos = "https://cloud.r-project.org", type = "source")' \
+  && installGithub.r \
+      cornelllabofornithology/auk \
+      ebird/ebirdst \
+      walkerke/mapboxapi \
+      bgreenwell/fastshap \
+      crazycapivara/h3-r \
+      imbs-hl/ranger \
+      # temporary bug fix, change back to CRAN once new version is on CRAN
+      datastorm-open/suncalc
 
 # Install AWS CLI v2
 RUN wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \

--- a/dockerst/Dockerfile
+++ b/dockerst/Dockerfile
@@ -67,7 +67,6 @@ RUN installGithub.r \
     bgreenwell/fastshap \
     crazycapivara/h3-r \
     imbs-hl/ranger \
-    ebird/fastmedian \ 
     # temporary bug fix, change back to CRAN once new version is on CRAN
     datastorm-open/suncalc
 

--- a/dockerst/Dockerfile
+++ b/dockerst/Dockerfile
@@ -10,11 +10,6 @@ RUN apt-get update -y \
     ffmpeg \
     imagemagick libmagick++-dev \
     rsync
-    
-# aws cli, instructions from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-  && unzip awscliv2.zip \
-  && ./aws/install
 
 # ImageMagick default policy we were getting was extremely restrictive
 # (Memory: 256MiB, Disk: 1GiB) which basically made it useless. We don't need

--- a/dockerst/Dockerfile
+++ b/dockerst/Dockerfile
@@ -1,13 +1,11 @@
 # docker image for ebird status and trends
 FROM mstrimas/geospatial
 
-MAINTAINER "Matt Strimas-Mackey" mes335@cornell.edu
 LABEL maintainer="Matt Strimas-Mackey <mes335@cornell.edu>"
 
 # system tools needed
 RUN apt-get update -y \
   && apt-get install -y \
-    awscli \
     expect \
     ffmpeg \
     imagemagick libmagick++-dev \
@@ -20,16 +18,29 @@ RUN apt-get update -y \
 RUN rm -f /etc/ImageMagick-6/policy.xml
 
 # Python packages
-RUN python3 -m pip install matplotlib \
-  && python3 -m pip install pandas \
-  && python3 -m pip install pyarrow \
-  && python3 -m pip install click \
-  && python3 -m pip install PyYAML \
-  && python3 -m pip install scikit_learn \
-  && python3 -m pip install scipy \
-  && python3 -m pip install torch \
-  && python3 -m pip install tqdm
-  
+#   We attempt to install as many as possible via apt-get for consistency.
+#   See: https://packaging.python.org/en/latest/specifications/externally-managed-environments/
+RUN apt-get update -y \
+  && apt-get install -y \
+    python3-arrow \
+    python3-click \
+    python3-matplotlib \
+    python3-pandas \
+    python3-scipy \
+    python3-sklearn \
+    python3-tqdm \
+    python3-yaml
+
+RUN apt-get update -y \
+  && apt-get install -y \
+    nvidia-cuda-toolkit
+
+# For ones not available via apt-get, we install via pip (ex: pytorch)
+#   See: https://stackoverflow.com/a/76469774/68736
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
+RUN python3 -m pip install \
+    torch
+
 # R packages needed
 RUN install.r \
     DBI DescTools MASS PresenceAbsence RSQLite \
@@ -47,8 +58,9 @@ RUN install.r \
     readr \
     scam sessioninfo smoothr \
     units uuid \
-    yardstick \
-  && installGithub.r \
+    yardstick
+
+RUN installGithub.r \
     cornelllabofornithology/auk \
     ebird/ebirdst \
     walkerke/mapboxapi \
@@ -58,15 +70,21 @@ RUN install.r \
     ebird/fastmedian \ 
     # temporary bug fix, change back to CRAN once new version is on CRAN
     datastorm-open/suncalc
-    
+
+# Install AWS CLI v2
+RUN wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip \
+  && unzip awscli-exe-linux-x86_64.zip \
+  && ./aws/install \
+  && rm -rf aws awscli-exe-linux-x86_64.zip
+
 # install duckdb, versions on cli, r, and python must match
-ENV DUCKDB_VERSION 0.9.2
+ENV DUCKDB_VERSION 0.10.2
 # must manually install libssl1.0.0
 RUN wget https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip \
   && unzip duckdb_cli-linux-amd64.zip -d /usr/bin/ \
   && rm duckdb_cli-linux-amd64.zip \
   && duckdb :memory: "INSTALL sqlite;" \
-  && r -e 'remotes::install_version("duckdb", version = "0.9.2", repos = "https://cloud.r-project.org")' \
+  && r -e 'remotes::install_version("duckdb", version = "'${DUCKDB_VERSION}'", repos = "https://cloud.r-project.org")' \
   && python3 -m pip install duckdb==${DUCKDB_VERSION}
 
 # install jags

--- a/geospatial/Dockerfile
+++ b/geospatial/Dockerfile
@@ -43,32 +43,21 @@ RUN git clone https://github.com/mapbox/tippecanoe.git \
   && rm -rf tippecanoe
   
 # install spatial packages, from https://hub.docker.com/r/rocker/geospatial/dockerfile
-RUN  r -e 'install.packages(c("rgdal", "sf", "lwgeom", "raster", "terra"), repos = "https://cloud.r-project.org", type = "source")' \
+RUN  r -e 'install.packages(c("rgdal", "s2", "sf", "lwgeom", "raster", "terra"), repos = "https://cloud.r-project.org", type = "source")' \
   && install.r \
-    RandomFields \
     RNetCDF \
     countrycode \
     classInt \
     fasterize \
-    geofacet \
-    gstat \
     hdf5r \
     janitor \
     landscapemetrics \
     mapproj \
     ncdf4 ncmeta tidync RNetCDF \
     proj4 \
-    raster \
-    rasterVis \
     rgeos \
     rnaturalearth rnaturalearthdata \
-    sp \
     stars \
-    spacetime \
-    spatstat \
-    spdep \
-    geoR \
-    geosphere \
   && installGithub.r \
     ropensci/rnaturalearthhires \ 
     rspatial/luna

--- a/geospatial/Dockerfile
+++ b/geospatial/Dockerfile
@@ -1,7 +1,6 @@
 # add r and python geospatial tools
 FROM mstrimas/tidyverse
 
-MAINTAINER "Matt Strimas-Mackey" mes335@cornell.edu
 LABEL maintainer="Matt Strimas-Mackey <mes335@cornell.edu>"
 
 # install spatial packages, from https://hub.docker.com/r/rocker/geospatial/dockerfile

--- a/geospatial/Dockerfile
+++ b/geospatial/Dockerfile
@@ -6,8 +6,6 @@ LABEL maintainer="Matt Strimas-Mackey <mes335@cornell.edu>"
 
 # install spatial packages, from https://hub.docker.com/r/rocker/geospatial/dockerfile
 RUN apt-get update \
-  # connect to ubuntugis/ubuntugis-unstable to get latest versions of spatial libraries
-  && add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y \
   && apt-get install -y \
     lbzip2 \
     libfftw3-dev \

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -70,7 +70,8 @@ RUN install.r \
   RColorBrewer viridis pals scico hexbin patchwork
 
 # install arrow, needs to be compiled from source
-RUN r -e 'options(repos = "https://cran.rstudio.com/"); Sys.setenv(LIBARROW_BINARY = TRUE); install.packages("arrow"", type = "source")'
+RUN r -e 'options(repos = "https://cran.rstudio.com/"); Sys.setenv(LIBARROW_BINARY = TRUE); install.packages("arrow", type = "source")'
+
 # install development version of stringi to avoid libicui version mismatch
 RUN installGithub.r gagolews/stringi
 

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -53,21 +53,25 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   unixodbc-dev \
   libsasl2-dev \
   libcurl4-openssl-dev \
-  libssl-dev \
-  && install.r \
-    tidyverse \
-    data.table \
-    geofacet \
-    jsonlite \
-    keyring \
-    plyr \
-    here \
-    foreach doParallel \
-    remotes pak \
-    RSQLite PostgreSQL arrow \
-    tictoc bench \
-    RColorBrewer viridis pals scico hexbin patchwork
-    
+  libssl-dev
+
+RUN install.r \
+  tidyverse \
+  data.table \
+  geofacet \
+  jsonlite \
+  keyring \
+  plyr \
+  here \
+  foreach doParallel \
+  remotes pak \
+  RSQLite PostgreSQL arrow \
+  tictoc bench \
+  RColorBrewer viridis pals scico hexbin patchwork
+
+# install development version of stringi to avoid libicui version mismatch
+RUN installGithub.r gagolews/stringi
+
 COPY start.sh /start.sh
 WORKDIR /home/docker/
 

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -70,7 +70,7 @@ RUN install.r \
   RColorBrewer viridis pals scico hexbin patchwork
 
 # install arrow, needs to be compiled from source
-RUN r -e 'options(repos = "https://cran.rstudio.com/"); Sys.setenv(LIBARROW_BINARY = TRUE); install.packages("arrow", type = "source")'
+RUN r -e 'Sys.setenv(LIBARROW_BINARY = TRUE); install.packages("arrow", repos = "https://cran.rstudio.com/", type = "source")'
 
 # install development version of stringi to avoid libicui version mismatch
 RUN installGithub.r gagolews/stringi

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -1,6 +1,5 @@
 FROM rstudio/r-base:4.4-noble
 
-MAINTAINER "Matt Strimas-Mackey" mes335@cornell.edu
 LABEL maintainer="Matt Strimas-Mackey <mes335@cornell.edu>"
 
 # set a default user, available via runtime flag `--user docker`

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -9,7 +9,7 @@ LABEL maintainer="Matt Strimas-Mackey <mes335@cornell.edu>"
 RUN useradd docker \
   && mkdir /home/docker \
   && chown docker:docker /home/docker \
-  && addgroup docker staff
+  && usermod -G staff docker
   
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -46,9 +46,9 @@ RUN R --slave -e 'install.packages(c("littler", "docopt"), repos = "https://clou
 RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libxml2-dev \
   libcairo2-dev \
-  libsqlite-dev \
+  libsqlite3-dev \
   libmariadbd-dev \
-  libmariadbclient-dev \
+  libmariadb-dev-compat \
   libpq-dev \
   libssh2-1-dev \
   unixodbc-dev \

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -1,4 +1,4 @@
-FROM rstudio/r-base:4.4-focal
+FROM rstudio/r-base:4.4-noble
 
 MAINTAINER "Matt Strimas-Mackey" mes335@cornell.edu
 LABEL maintainer="Matt Strimas-Mackey <mes335@cornell.edu>"

--- a/tidyverse/Dockerfile
+++ b/tidyverse/Dockerfile
@@ -65,10 +65,12 @@ RUN install.r \
   here \
   foreach doParallel \
   remotes pak \
-  RSQLite PostgreSQL arrow \
+  RSQLite PostgreSQL \
   tictoc bench \
   RColorBrewer viridis pals scico hexbin patchwork
 
+# install arrow, needs to be compiled from source
+RUN r -e 'options(repos = "https://cran.rstudio.com/"); Sys.setenv(LIBARROW_BINARY = TRUE); install.packages("arrow"", type = "source")'
 # install development version of stringi to avoid libicui version mismatch
 RUN installGithub.r gagolews/stringi
 


### PR DESCRIPTION
Hey Matt, what do you think about updating this to be based on a new version of Ubuntu? It looks like this was pinned to Ubuntu 20.04 (from 2020). This includes python 3.8 which is starting to get pretty different than the current 3.12 (as you and Myles noted when my type annotations started causing parsing errors)?

I'm sure we'll need to do some testing once we switch to make sure the new version works well, so no need to move quickly on merging this PR, but just wanted to get the ball rolling.