### PR TITLE
should build but not push to dockerhub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # tidyverse
-      - name: Build and push tidyverse image
+      - name: Build and conditionally push tidyverse image
         uses: docker/build-push-action@v5
         with:
           context: ./tidyverse
@@ -47,7 +47,7 @@ jobs:
           tags: mstrimas/tidyverse:latest
           
       # geospatial
-      - name: Build and push geospatial image
+      - name: Build and conditionally push geospatial image
         uses: docker/build-push-action@v5
         with:
           context: ./geospatial
@@ -56,7 +56,7 @@ jobs:
           tags: mstrimas/geospatial:latest
           
       # dockerst
-      - name: Build and push dockerst image
+      - name: Build and conditionally push dockerst image
         uses: docker/build-push-action@v5
         with:
           context: ./dockerst

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           context: ./tidyverse
           file: ./tidyverse/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: mstrimas/tidyverse:latest
           
       # geospatial
@@ -52,7 +52,7 @@ jobs:
         with:
           context: ./geospatial
           file: ./geospatial/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: mstrimas/geospatial:latest
           
       # dockerst
@@ -61,5 +61,5 @@ jobs:
         with:
           context: ./dockerst
           file: ./dockerst/Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: mstrimas/dockerst:latest


### PR DESCRIPTION
Unless we are pushing to main (e.g., merging a PR to main), we should not push to dockerhub. 

Note that this [step](https://github.com/ebird/docker/actions/runs/12191149424/job/34009534219) completed:
<img width="871" alt="image" src="https://github.com/user-attachments/assets/8277b721-7bfd-4a3a-9708-572213325b8f">

But it did not update the [image](https://hub.docker.com/layers/mstrimas/tidyverse/latest/images/sha256-9e3f4d444948ebd54c126ee9d8aec45d3c5e12c809e3ed7470660bf68cb69011?context=explore) in dockerhub.

You can safely ignore the failure, I cancelled the action because it got past the part that needed testing.